### PR TITLE
optimize Rust <-> R conversions, multipliers and imports

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -3,8 +3,7 @@ mod multipliers;
 mod influence;
 mod linkages;
 
-use faer;
-use faer::prelude::SpSolver;
+use faer::{Mat, prelude::SpSolver};
 use extendr_api::prelude::*;
 use rayon::prelude::*;
 
@@ -29,7 +28,7 @@ fn compute_tech_coeff(
     .map(|(i, value)| value / total_production[i / n])
     .collect();
 
-  RArray::new_matrix(n, n, |r, c| tech_coeff[r + c* n])
+  RArray::new_matrix(n, n, |row, column| tech_coeff[row + column * n])
 }
 
 #[extendr]
@@ -43,10 +42,10 @@ fn compute_leontief_inverse(tech_coeff: &[f64]) -> RArray<f64, [usize;2]> {
   let n = (tech_coeff.len() as f64).sqrt() as usize;
 
   // create faer matrix
-  let tech_coeff_matrix = faer::Mat::from_fn(n, n, |row, col| tech_coeff[col * n + row]);
+  let tech_coeff_matrix = Mat::from_fn(n, n, |row, col| tech_coeff[col * n + row]);
 
   // calculate Leontief matrix
-  let identity_matrix: faer::Mat<f64> = faer::Mat::identity(n, n);
+  let identity_matrix: Mat<f64> = Mat::identity(n, n);
   let leontief_matrix = &identity_matrix - tech_coeff_matrix;
 
   // calculate Leontief inverse

--- a/src/rust/src/linkages.rs
+++ b/src/rust/src/linkages.rs
@@ -1,5 +1,6 @@
 use extendr_api::prelude::*;
 use rayon::prelude::*;
+use faer::Mat;
 
 #[extendr]
 /// Computes average of elements of Leontief inverse matrix
@@ -25,7 +26,7 @@ fn compute_row_average(
   let n = (leontief_inverse_matrix.len() as f64).sqrt() as usize;
 
   // convert to faer matrix
-  let leontief_inverse_matrix_faer = faer::Mat::from_fn(n, n, |row, col| leontief_inverse_matrix[col * n + row]);
+  let leontief_inverse_matrix_faer = Mat::from_fn(n, n, |row, col| leontief_inverse_matrix[col * n + row]);
 
   // get row means
   let mut indexed_results: Vec<(usize, f64)> = leontief_inverse_matrix_faer.row_iter()

--- a/src/rust/src/multipliers.rs
+++ b/src/rust/src/multipliers.rs
@@ -1,4 +1,5 @@
 use extendr_api::prelude::*;
+use rayon::prelude::*;
 
 #[extendr]
 /// Calculates output multiplier.
@@ -6,22 +7,17 @@ use extendr_api::prelude::*;
 /// @return A 1xn vector of output multipliers.
 
 fn compute_multiplier_output(
-  leontief_inverse_matrix: Vec<f64>
+  leontief_inverse_matrix: &[f64]
 ) -> Vec<f64> {
   
   // get dimensions (square root of length)
   let n = (leontief_inverse_matrix.len() as f64).sqrt() as usize;
 
   // get column sums
-  let mut mult_out = vec![0.0; n];
-  for i in 0..n {
-    for j in 0..n {
-      let index = i * n + j;
-      mult_out[j] += leontief_inverse_matrix[index];
-    }
-  }
-
-  mult_out
+  leontief_inverse_matrix
+    .par_chunks(n)
+    .map(|col| col.iter().sum())
+    .collect::<Vec<f64>>()
 }
 
 // Macro to generate exports.

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Get data ready for input-output analysis"
 date: '`r format(Sys.Date(), "%B %d, %Y")`'
 output: rmarkdown::html_vignette
 vignette: >


### PR DESCRIPTION
- Optimize Rust <-> R conversions, using Matrix objects instead of single vector
- Parallelize output multiplier
- Fix faer imports