### PR TITLE
Fix build on Windows ARM64

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,7 @@ jobs:
           - { os: windows-2025, r: "release" }
           - { os: windows-2025, r: "devel" }
           - { os: windows-2025, r: "oldrel-1" }
+          - { os: windows-11-arm, r: "release" }
           - { os: ubuntu-24.04-arm, r: "release" }
           - { os: ubuntu-24.04-arm, r: "devel" }
           - { os: ubuntu-24.04, r: "devel" }
@@ -54,6 +55,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - if: ${{ runner.os == 'windows' && runner.arch == 'ARM64' }}
+        run: rustup target add aarch64-pc-windows-gnullvm
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,4 +1,4 @@
-TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET = @WINDOWS_TARGET@
 
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/@LIBDIR@

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
 
 [[package]]
 name = "extendr-api"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea54977c6e37236839ffcbc20b5dcea58aa32ae43fbef54a81e1011dc6b19061"
+checksum = "e002a15028421248374d3beb66d1802ce70d738b666a043a1f4dfffad14bc595"
 dependencies = [
  "extendr-ffi",
  "extendr-macros",
@@ -246,15 +246,15 @@ dependencies = [
 
 [[package]]
 name = "extendr-ffi"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76777174a82bdb3e66872f580687d3d0143eed1df9b9cd72b321b9596a23ca7"
+checksum = "acf3ace33b895bdfc13d02fd7486b26dc71078c256f3399f6272f8bd70fc3a1e"
 
 [[package]]
 name = "extendr-macros"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661cc4ae29de9c4dafe16cfcbda1dbb9f31bd2568f96ebad232cc1f9bcc8b04d"
+checksum = "f6b27baf9abffe403f3051efea3c19a0f315be9ec5f1c80efbade1aee5ccccbc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = [ 'staticlib' ]
 name = 'fio'
 
 [dependencies]
-extendr-api = { version = '0.8.1', default-features = false }
+extendr-api = { version = '0.8.2', default-features = false }
 rayon = { version = '1.10.0', default-features = false }
 num_cpus = { version = '1.16.0', default-features = false }
 faer = { version = '0.24.0', default-features = false, features = ["rayon"] }

--- a/tools/config.R
+++ b/tools/config.R
@@ -96,8 +96,19 @@ if (file.exists(mv_ofp)) {
 # read as a single string
 mv_txt <- readLines(mv_fp)
 
+.windows_target <- if (grepl("aarch", R.version$platform)) {
+  "aarch64-pc-windows-gnullvm"
+} else if (grepl("clang", Sys.getenv("R_COMPILED_BY"))) {
+  "x86_64-pc-windows-gnullvm"
+} else if (grepl("i386", R.version$platform)) {
+  "i686-pc-windows-gnu"
+} else {
+  "x86_64-pc-windows-gnu"
+}
+
 # replace placeholder values
 new_txt <- gsub("@CRAN_FLAGS@", .cran_flags, mv_txt) |>
+  gsub("@WINDOWS_TARGET@", .windows_target, x = _) |>
   gsub("@PROFILE@", .profile, x = _) |>
   gsub("@CLEAN_TARGET@", .clean_targets, x = _) |>
   gsub("@LIBDIR@", .libdir, x = _) |>


### PR DESCRIPTION
This fixes the build on Windows ARM64.

Before: https://github.com/r-universe/cran/actions/runs/30698877491/attempts/1
After: https://github.com/r-universe/cran/actions/runs/30698877491/job/91416929305

It bumps `extendr-api` to 0.8.2 (which supports Windows ARM64) and unconditionally passes the correct `--target` on Windows. The vendored crates are updated to match.

For more details see https://github.com/r-devel/windows-arm64